### PR TITLE
_id typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -461,7 +461,7 @@
     "search_after": [1463538857, "654323"],
     "sort": [
         {"date": "asc"},
-        {"_uid": "desc"}
+        {"_id": "desc"}
     ]
 }</code></pre>
 


### PR DESCRIPTION
I think `_uid` slipped in there by mistake